### PR TITLE
Fixed Issue #6

### DIFF
--- a/metagol.pl
+++ b/metagol.pl
@@ -280,7 +280,7 @@ assert_clause(Sub):-
     assert(user:Clause).
 
 assert_prims(Prog):-
-    findall(P/A,(member(sub(_Name,P,A,_MetaSub),Prog)),Prims),!,
+    findall(P/A,(member(sub(_Name,P,A,_MetaSub,_PredTypes),Prog)),Prims),!,
     list_to_set(Prims,PrimSet),
     maplist(assert_prim,PrimSet).
 


### PR DESCRIPTION
I have tracked down issue #6 to a small error in assert_prims/1. The predicate expected Prog to be a list of sub/4 terms. However, this structure was changed to sub/5 terms in version 2.2.0. Since the type of the predicates (the fifth argument) are of no concern when asserting primitives, I corrected the syntax without any semantic changes.